### PR TITLE
dzil-actions/build: no more v5.8 testing

### DIFF
--- a/build/action.yaml
+++ b/build/action.yaml
@@ -66,6 +66,10 @@ runs:
       )
       echo "minimum-perl $PERL_MINIMUM"
       PERL_MINIMUM_NORMAL=$(perl -Mversion -E "say version->parse(q{$PERL_MINIMUM})->normal")
+      if [ "$PERL_MINIMUM_NORMAL" eq "v5.8.0" ]; then
+        echo "can't test on v5.8.0, bumping to v5.10.1"
+        PERL_MINIMUM_NORMAL=v5.10.1
+      fi
       echo "minimum-perl-normal $PERL_MINIMUM_NORMAL"
       echo "minimum-perl=$PERL_MINIMUM_NORMAL" >> $GITHUB_OUTPUT
   - name: Get testable perl versions


### PR DESCRIPTION
Test2::Harness and the JUnit formatter now require v5.10.0 and v5.10.1 respectively.  Code being tested might work on v5.8.0, but I am not interested in changing the test infrastructure for the sake of such an obsolete perl.  With this change, we might still ship something that can run on v5.8, but it won't be tested (or supported).